### PR TITLE
Updating dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject org.clojars.scsibug/feedparser-clj "0.3"
+(defproject org.clojars.scsibug/feedparser-clj "0.4.0"
   :description "Parse RSS/Atom feeds with a simple, clojure-friendly API."
-  :dependencies [[org.clojure/clojure "1.3.0"]
-		 [org.jdom/jdom "1.1"]
+  :dependencies [[org.clojure/clojure "1.4.0"]
+		 [org.jdom/jdom "2.0.1"]
 		 [net.java.dev.rome/rome "1.0.0"]]
   :main feedparser-clj.core)


### PR DESCRIPTION
Updated to Clojure 1.4 and JDOM 2.0.1, and bumped version number to 0.4.0.
