### PR TITLE
Add example showing how parse-feed can accept input from file/other sources.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,19 @@ Retrieve and parse a feed:
 
     user=> (def f (parse-feed "http://gregheartsfield.com/atom.xml"))
 
+`parse-feed` also accepts a java.io.InputStream for reading from a file or other sources (see [clojure.java.io/input-stream](http://richhickey.github.com/clojure/clojure.java.io-api.html#clojure.java.io/input-stream)):
+
+    ;; Contents of resources/feed.rss
+    <rss>
+      ...
+    </rss>
+
+    user=> (def f (with-open
+                    [feed-stream (-> "feed.rss"
+                                     clojure.java.io/resource
+                                     clojure.java.io/input-stream)]
+                    (parse-feed feed-stream)))
+
 `f` is now a map that can be accessed by key to retrieve feed information:
 
     user=> (keys f)


### PR DESCRIPTION
Hi, for testing purposes I wanted to be able to parse feeds from disk, but I had to dig through the underlying ROME source code to figure out how to do it.  Hopefully updating the documentation to support this use case will be useful for others in the future.  Thanks!
